### PR TITLE
JAMEDA: Deactivate Callstats Precall Test

### DIFF
--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -379,6 +379,11 @@ export default class CallStats {
                 configParams.siteID = options.siteID || (match && match[1]) || '/';
             }
 
+            // @JAMEDA-PATCH: Deactivate Callstats Precall Test
+            if (options.callStatsPrecallTestDisabled) {
+                configParams.disablePrecallTest = true;
+            }
+
             // userID is generated or given by the origin server
             CallStats.backend.initialize(
                 CallStats.callStatsID,


### PR DESCRIPTION
In Jitsi the Callstats PreCallTest ist activate by default. I add an config param to make it possible to deactivate the PreCallTest.